### PR TITLE
Upgrade to upstream package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/mble/slamhound
 go 1.13
 
 require (
+	github.com/hillu/go-yara/v4 v4.3.2
 	github.com/karrick/godirwalk v1.15.3
 	github.com/klauspost/compress v1.9.8 // indirect
 	github.com/klauspost/pgzip v1.2.1
-	github.com/mble/go-yara v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
+github.com/hillu/go-yara/v4 v4.3.2 h1:HGqUN3ORUduWZbb95RQjut4UzavGDbtt/C6SnGB3Amk=
+github.com/hillu/go-yara/v4 v4.3.2/go.mod h1:AHEs/FXVMQKVVlT6iG9d+q1BRr0gq0WoAWZQaZ0gS7s=
 github.com/karrick/godirwalk v1.15.3 h1:0a2pXOgtB16CqIqXTiT7+K9L73f74n/aNQUnH6Ortew=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82QyA=
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM=
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
-github.com/mble/go-yara v1.2.1 h1:FmqzHnjqswOhtaNX8+lXvAwwmyDAg2HXDShL7rzVvLs=
-github.com/mble/go-yara v1.2.1/go.mod h1:1l6NK7yc6IJYiBTh55Qr4FX0noTUnsG+TKjfK3MUSfY=

--- a/pkg/slamhound/hound.go
+++ b/pkg/slamhound/hound.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hillu/go-yara/v4"
 	"github.com/karrick/godirwalk"
-	"github.com/mble/go-yara"
 	"github.com/mble/slamhound/pkg/cfg"
 )
 

--- a/pkg/slamhound/hound.go
+++ b/pkg/slamhound/hound.go
@@ -15,7 +15,7 @@ import (
 // such as the rules and config for the scanner
 type Hound struct {
 	config *cfg.Config
-	rules  yara.Rules
+	rules  *yara.Rules
 }
 
 // Compile compiles the rules based on configuration and readies
@@ -33,7 +33,7 @@ func (h *Hound) Compile(rulesDir string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to compile rules: %w", err)
 	}
-	h.rules = *rules
+	h.rules = rules
 	return err
 }
 
@@ -56,7 +56,7 @@ func (h *Hound) CompileSingularRule(rule string) error {
 	if err != nil {
 		return err
 	}
-	h.rules = *rules
+	h.rules = rules
 	return err
 }
 

--- a/pkg/slamhound/pipeline.go
+++ b/pkg/slamhound/pipeline.go
@@ -29,7 +29,7 @@ func setVariables(scanner *yara.Scanner, relPath string) error {
 	return nil
 }
 
-func inMemoryScan(rules yara.Rules, filename string, skipList []string) ([]Result, error) {
+func inMemoryScan(rules *yara.Rules, filename string, skipList []string) ([]Result, error) {
 	runtime.LockOSThread()
 	results := []Result{}
 	// Set up the tar reader
@@ -43,7 +43,7 @@ func inMemoryScan(rules yara.Rules, filename string, skipList []string) ([]Resul
 	}
 	defer gzr.Close()
 
-	scanner, err := yara.NewScanner(&rules)
+	scanner, err := yara.NewScanner(rules)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func inMemoryScan(rules yara.Rules, filename string, skipList []string) ([]Resul
 	return results, nil
 }
 
-func fileWalkScan(rules yara.Rules, directory string, skipList []string) ([]Result, error) {
+func fileWalkScan(rules *yara.Rules, directory string, skipList []string) ([]Result, error) {
 	results := []Result{}
 	done := make(chan struct{})
 	defer close(done)
@@ -149,9 +149,9 @@ func walkFiles(done <-chan struct{}, directory string, skipList []string) (<-cha
 	return paths, errc
 }
 
-func fileScanner(rules yara.Rules, done <-chan struct{}, paths <-chan string, results chan<- Result) {
+func fileScanner(rules *yara.Rules, done <-chan struct{}, paths <-chan string, results chan<- Result) {
 	runtime.LockOSThread()
-	scanner, err := yara.NewScanner(&rules)
+	scanner, err := yara.NewScanner(rules)
 	if err != nil {
 		results <- Result{Err: err}
 		return

--- a/pkg/slamhound/pipeline.go
+++ b/pkg/slamhound/pipeline.go
@@ -10,10 +10,10 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/hillu/go-yara/v4"
 	"github.com/karrick/godirwalk"
 	gzip "github.com/klauspost/pgzip"
 
-	"github.com/mble/go-yara"
 	"github.com/mble/slamhound/pkg/untar"
 )
 
@@ -75,7 +75,9 @@ func inMemoryScan(rules *yara.Rules, filename string, skipList []string) ([]Resu
 			if err != nil {
 				return nil, err
 			}
-			matches, err := scanner.ScanMem(buf, 0, 0)
+			var matches yara.MatchRules
+			scanner.SetCallback(&matches)
+			err = scanner.ScanMem(buf)
 			if err != nil {
 				return nil, err
 			}
@@ -165,7 +167,9 @@ func fileScanner(rules *yara.Rules, done <-chan struct{}, paths <-chan string, r
 				return
 			}
 		}
-		matches, err := scanner.ScanFile(path, 0, 0)
+		var matches yara.MatchRules
+		scanner.SetCallback(&matches)
+		err = scanner.ScanFile(path)
 		select {
 		case results <- Result{path, matches, err}:
 		case <-done:

--- a/pkg/slamhound/result.go
+++ b/pkg/slamhound/result.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mble/go-yara"
+	"github.com/hillu/go-yara/v4"
 )
 
 // Result is a struct containing the results of scanning a file

--- a/pkg/slamhound/result_test.go
+++ b/pkg/slamhound/result_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mble/go-yara"
+	"github.com/hillu/go-yara/v4"
 )
 
 func TestFormatMatches(t *testing.T) {


### PR DESCRIPTION
This is an attempt upgrading from the [github.com/mble/go-yara](https://github.com/mble/go-yara) fork onto the upstream [github.com/hillu/go-yara](https://github.com/hillu/go-yara).

The scanner implementation was merged in hillu/go-yara#60.

However, this currently fails for tarball scans unless run with `GOGC` set to "off". I'll see if I can figure out why that happens.